### PR TITLE
Added support for out-of-band VLAN tagging.

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -288,6 +288,7 @@ retry:
 	ci.CaptureLength = len(data)
 	ci.Length = h.current.getLength()
 	ci.InterfaceIndex = h.current.getIfaceIndex()
+	ci.VLAN = h.current.getVLAN()
 	atomic.AddInt64(&h.stats.Packets, 1)
 	h.headerNextNeeded = true
 	h.mu.Unlock()

--- a/afpacket/options.go
+++ b/afpacket/options.go
@@ -100,6 +100,10 @@ type OptPollTimeout time.Duration
 // time it goes through AF_PACKET.  If this option is true, the VLAN header is
 // added back in before the packet is returned.  Note that this potentially has
 // a large performance hit, especially in otherwise zero-copy operation.
+//
+// Note that if you do not need to have a "real" VLAN layer, it may be
+// preferable to use the VLAN ID provided in gopacket.CaptureInfo.VLAN,
+// which is populated out-of-band and has negligible performance impact.
 type OptAddVLANHeader bool
 
 // Default constants used by options.

--- a/packet.go
+++ b/packet.go
@@ -31,6 +31,12 @@ type CaptureInfo struct {
 	Length int
 	// InterfaceIndex
 	InterfaceIndex int
+	// VLAN is the VLAN ID if one was provided out-of-band by the
+	// capture mechanism. If no ID was provided, this will be -1.
+	// Note that this can be -1 and a VLAN header still present
+	// if the capture mechanism does not support out-of-band reporting
+	// of VLAN IDs.
+	VLAN int
 }
 
 // PacketMetadata contains metadata for a packet.


### PR DESCRIPTION
The Linux kernel suports VLAN offloading, which can end up
stripping VLAN headers off of captured packets.

For those who need it, the `afpacket.OptAddVLANHeader` option
will add in a synthetic VLAN header created from the out-of-
band information reported by the kernel. This is great, but
slow.

This commit instead provides that information out-of-band,
which is faster but works out-of-band from the normal layer
decoding mechanism.